### PR TITLE
Add reset counter for an identifier.

### DIFF
--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -100,6 +100,23 @@ class Throttle
     }
 
     /**
+     * Reset couter
+     *
+     * @param string $identifier
+     * @return $this
+     * @throws CacheInvalidArgumentException
+     */
+    public function reset(string $identifier): Throttle
+    {
+        foreach ($this->conditions as $condition) {
+            $key = sprintf('%s-%s', $identifier, $condition);
+            $this->cache->deleteItem($key);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $identifier
      * @param Condition $condition
      * @return CacheItemInterface

--- a/tests/unit/ThrottleTest.php
+++ b/tests/unit/ThrottleTest.php
@@ -237,4 +237,15 @@ class ThrottleTest extends TestCase
 
         $this->assertEquals($intervals, $sut->getIntervals(self::TEST_GET_INTERVALS_IDENTIFIER));
     }
+
+
+    public function testReset()
+    {
+        $cache = \Mockery::mock(CacheItemPoolInterface::class);
+        $cache->expects('deleteItem')->once()->andReturn(true);
+        $sut = new Throttle($cache);
+        $sut->add(new Condition(self::TEST_INCREMENT_TTL, self::TEST_INCREMENT_LIMIT));
+
+        $this->assertInstanceOf(Throttle::class, $sut->reset(self::TEST_INCREMENT_IDENTIFIER));
+    }
 }


### PR DESCRIPTION
Adds a reset function for clear an specific identifier.

Use case: Login invalid attemps for specific username. The username counter is reset when a valid login is detected.
