### PR TITLE
Always force TTL

### DIFF
--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -68,8 +68,8 @@ class Throttle
                 $interval = $item->get();
             } else {
                 $interval = new Interval($condition->getTtl());
-                $item->expiresAfter($condition->getTtl());
             }
+            $item->expiresAfter($condition->getTtl());
             $interval->count += $count;
             $item->set($interval);
             $this->cache->save($item);


### PR DESCRIPTION
Force in cache items TTL too

I'm using Symfony filesystem cache (https://symfony.com/doc/current/components/cache.html#basic-usage-psr-6) and I detected that expiration time is modify to default adapter value after second usage.
